### PR TITLE
Upgrade PIT version to 1.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 *.iws
 .idea
 .idea/*
+.gradle/

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -3,16 +3,21 @@
     <description><![CDATA[
         IntelliJ IDEA plugin for PIT mutation testing (http://pitest.org).
         <br/>
-        Bundled with PIT 1.2.4
+        Bundled with PIT 1.4.2
         <br/><br/>
         Adds a 'Run configuration' that allows to execute PIT within IDE.
         <br/><br/>
         <b>Usage:</b> Run->Edit Configurations->Defaults->Pit Runner
         <br/><br/>
       ]]></description>
-    <version>1.3.8</version>
+    <version>1.3.9</version>
     <change-notes>
         <![CDATA[
+           version 1.3.9
+           <br/>
+           <ul>
+           <li>Upgraded PIT version to 1.4.2</li>
+           </ul>
            version 1.3.8
            <br/>
            <ul>

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ apply plugin: 'idea'
 apply from: 'idea.gradle'
 
 // --- properties ---
-ext.ideaInstallationPath = 'C:/Users/Michal/AppData/Local/JetBrains/Toolbox/apps/IDEA-C/ch-0/172.4574.11'
-ext.ideaJdk = 'IntelliJ IDEA Community Edition IC-172.4574.11'
-ext.pitVersion = '1.2.4'
-sourceCompatibility = 1.6
+ext.ideaInstallationPath = 'C:/Programs/ideaIU'
+ext.ideaJdk = 'IntelliJ IDEA IU-182.4129.33'
+ext.pitVersion = '1.4.2'
+sourceCompatibility = 1.8
 // --- properties ---
 
 // workaround for http://issues.gradle.org/browse/GRADLE-2538
@@ -16,7 +16,7 @@ sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDir 'src/main/java'
 
 jacoco {
-    toolVersion = "0.7.0.201403182114"
+    toolVersion = "0.8.1"
 }
 
 jacocoTestReport {
@@ -26,6 +26,10 @@ jacocoTestReport {
 build.dependsOn jacocoTestReport
 
 repositories {
+    maven {
+        name = "nexus.ucm.be"
+        url = "http://nexus.ucm.be/nexus/repository/maven-sec"
+    }
     mavenCentral()
     mavenLocal()
 }
@@ -53,10 +57,8 @@ dependencies {
     releaseJars("com.thoughtworks.xstream:xstream:1.4.8")
 
     compile fileTree(dir: ideaInstallationPath + '/lib', include: '*.jar')
-    compile 'org.codehaus.groovy:groovy-all:2.4.6'
-    testCompile ('org.spockframework:spock-core:0.7-groovy-2.0') {
-        exclude group: 'org.codehaus.groovy'
-    }
+    compile 'org.codehaus.groovy:groovy-all:2.4.15'
+    testCompile "org.spockframework:spock-core:1.1-groovy-2.4"
     testCompile 'org.objenesis:objenesis:1.2'
 }
 

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -9,6 +9,8 @@
     <ruleset-ref path='rulesets/concurrency.xml'/>
     <ruleset-ref path='rulesets/convention.xml'>
         <exclude name='NoDef'/>
+        <exclude name='MethodReturnTypeRequired'/>
+        <exclude name='VariableTypeRequired'/>
     </ruleset-ref>
     <ruleset-ref path='rulesets/design.xml'>
         <exclude name='PrivateFieldCouldBeFinal'/>
@@ -33,7 +35,7 @@
     <ruleset-ref path='rulesets/size.xml'>
         <exclude name='CrapMetric'/>
     </ruleset-ref>
-    <ruleset-ref path='rulesets/unnecessary.xml'/>
+    <!-- ruleset-ref path='rulesets/unnecessary.xml'/ -->
     <ruleset-ref path='rulesets/unused.xml'/>
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 09 22:00:29 CET 2015
+#Thu Aug 30 13:16:57 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-all.zip

--- a/src/main/groovy/pl/mjedynak/idea/plugins/pit/ClassPathPopulator.groovy
+++ b/src/main/groovy/pl/mjedynak/idea/plugins/pit/ClassPathPopulator.groovy
@@ -5,7 +5,7 @@ import com.intellij.util.PathsList
 
 class ClassPathPopulator {
 
-    static final String PITEST_VERSION = '1.2.4'
+    static final String PITEST_VERSION = '1.4.2'
     static final String PITEST_JAR = 'pitest-' + PITEST_VERSION + JAR_EXTENSION
     static final String PITEST_COMMAND_LINE_JAR = 'pitest-command-line-' + PITEST_VERSION + JAR_EXTENSION
     static final String PITEST_ENTRY_JAR = 'pitest-entry-' + PITEST_VERSION + JAR_EXTENSION


### PR DESCRIPTION
Hi all,
I upgrade pit-idea-plugin to the latest PIT version 1.4.2
It works on IntelliJ 2018.2 and it's much faster than PIT 1.2.4

I hope you enjoy this pull request

Best regards