### PR TITLE
WIP: Add context menu actions (fixes #6)

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -109,6 +109,18 @@
     </project-components>
 
     <actions>
+        <action id="pitest.RunAllPit" class="pl.mjedynak.idea.plugins.pit.actions.RunAllPitAction" text="Pitest all tests in module" description="Mutate all tests against all classes in the project" icon="/pit.gif">
+            <add-to-group group-id="ProjectViewPopupMenuRunGroup" anchor="last"/>
+            <add-to-group group-id="EditorPopupMenu.Run" anchor="last"/>
+        </action>
+        <action id="pitest.RunSomePit"
+                class="pl.mjedynak.idea.plugins.pit.actions.RunSomeTestsPitAction" text="Pitest with these tests" description="Mutate only the tests in this directory against all classes in the project" icon="/pit.gif">
+            <add-to-group group-id="ProjectViewPopupMenuRunGroup" anchor="last"/>
+        </action>
+        <action id="pitest.TestSomePit"
+                class="pl.mjedynak.idea.plugins.pit.actions.PitTestSomeClassesAction" text="Pitest these classes" description="Mutate all tests against the classes in this directory" icon="/pit.gif">
+            <add-to-group group-id="ProjectViewPopupMenuRunGroup" anchor="last"/>
+        </action>
     </actions>
 
     <extensions defaultExtensionNs="com.intellij">

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
 jar {
     metaInf {
-        from('/META-INF') {
+        from('META-INF') {
             include 'plugin.xml'
         }
     }

--- a/src/main/groovy/pl/mjedynak/idea/plugins/pit/configuration/PitRunConfigurationStorer.groovy
+++ b/src/main/groovy/pl/mjedynak/idea/plugins/pit/configuration/PitRunConfigurationStorer.groovy
@@ -7,6 +7,7 @@ import pl.mjedynak.idea.plugins.pit.gui.PitConfigurationForm
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.REPORT_DIR
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.SOURCE_DIRS
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_CLASSES
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_TESTS
 
 @CompileStatic
 class PitRunConfigurationStorer {
@@ -17,6 +18,7 @@ class PitRunConfigurationStorer {
         pitConfigurationForm.setReportDir(element.getAttribute(REPORT_DIR.toString())?.value)
         pitConfigurationForm.setSourceDir(element.getAttribute(SOURCE_DIRS.toString())?.value)
         pitConfigurationForm.setTargetClasses(element.getAttribute(TARGET_CLASSES.toString())?.value)
+        pitConfigurationForm.setTargetTests(element.getAttribute(TARGET_TESTS.toString())?.value)
         pitConfigurationForm.setOtherParams(element.getAttribute(OTHER_PARAMS)?.value)
     }
 
@@ -24,6 +26,7 @@ class PitRunConfigurationStorer {
         element.setAttribute(REPORT_DIR.toString(), pitConfigurationForm.reportDir)
         element.setAttribute(SOURCE_DIRS.toString(), pitConfigurationForm.sourceDir)
         element.setAttribute(TARGET_CLASSES.toString(), pitConfigurationForm.targetClasses)
+        element.setAttribute(TARGET_TESTS.toString(), pitConfigurationForm.targetTests)
         element.setAttribute(OTHER_PARAMS, pitConfigurationForm.otherParams)
     }
 

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/DirectoryOrFilePitAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/DirectoryOrFilePitAction.java
@@ -1,0 +1,71 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfiguration;
+
+import java.util.List;
+
+public abstract class DirectoryOrFilePitAction extends PitAction {
+
+    abstract String getTitleForItem(final String item);
+
+    abstract boolean isEnabled(@NotNull final Project project, @NotNull final Module module,
+                               @NotNull final VirtualFile vfile);
+
+    @Override
+    public void update(@NotNull final AnActionEvent e) {
+        final Project project = e.getData(DataKeys.PROJECT);
+        final Module module = e.getData(DataKeys.MODULE);
+        final VirtualFile vfile = e.getData(DataKeys.VIRTUAL_FILE);
+
+        final boolean enabled = (project != null) && (module != null) && (vfile != null)
+                && isEnabled(project, module, vfile);
+
+        e.getPresentation().setEnabledAndVisible(enabled);
+        if (enabled) {
+            e.getPresentation().setText(getTitleForItem(vfile.getPresentableName()));
+        }
+    }
+
+    abstract PitRunConfiguration makeConfigurationForClassList(@NotNull final String classList,
+                                                               @NotNull final Project project,
+                                                               @NotNull final String title);
+
+
+    @Override
+    protected PitRunConfiguration getConfigurationForActionEvent(final AnActionEvent e) {
+        final Project project = e.getData(DataKeys.PROJECT);
+        final Module module = e.getData(DataKeys.MODULE);
+        final VirtualFile vfile = e.getData(DataKeys.VIRTUAL_FILE);
+
+        if ((project == null) || (module == null) || (vfile == null) || !isEnabled(project, module, vfile)) {
+            return null;
+        }
+
+        final List<String> classNames;
+        if (vfile.isDirectory()) {
+            final PsiDirectory psiDirectory = PsiManager.getInstance(project).findDirectory(vfile);
+            classNames = PitActionUtils.getClassNamesInDirectory(psiDirectory);
+        } else {
+            final PsiFile psiFile = PsiManager.getInstance(project).findFile(vfile);
+            classNames = PitActionUtils.getClassNamesForFile(psiFile);
+        }
+
+        if (classNames.isEmpty()) {
+            return null;
+        }
+
+        final String joinedString = String.join(",", classNames);
+
+        return makeConfigurationForClassList(joinedString, project, vfile.getPresentableName());
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitAction.java
@@ -1,0 +1,51 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.execution.ProgramRunnerUtil;
+import com.intellij.execution.executors.DefaultRunExecutor;
+import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfiguration;
+
+abstract public class PitAction extends AnAction {
+
+    @Override
+    public void update(@NotNull final AnActionEvent e) {
+        final Project project = e.getData(DataKeys.PROJECT);
+        final Module module = e.getData(DataKeys.MODULE);
+        final boolean available = (project != null) && (module != null);
+        e.getPresentation().setEnabledAndVisible(available);
+    }
+
+    @Override
+    public final void actionPerformed(final AnActionEvent e) {
+        final Project project = e.getData(DataKeys.PROJECT);
+        final Module module = e.getData(DataKeys.MODULE);
+        if (project == null || module == null) {
+            return;
+        }
+
+        final PitRunConfiguration pitRunConfiguration = getConfigurationForActionEvent(e);
+
+        if (pitRunConfiguration == null) {
+            return;
+        }
+
+        final ExecutionEnvironmentBuilder builder = ExecutionEnvironmentBuilder.create(DefaultRunExecutor.getRunExecutorInstance(), pitRunConfiguration);
+
+        ProgramRunnerUtil.executeConfiguration(builder
+                .contentToReuse(null)
+                .dataContext(null)
+                .activeTarget()
+                .build(), true, true);
+
+    }
+
+    @Nullable abstract PitRunConfiguration getConfigurationForActionEvent(final AnActionEvent e);
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitActionUtils.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitActionUtils.java
@@ -1,0 +1,51 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiJavaFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PitActionUtils {
+
+    private PitActionUtils() {
+    }
+
+    @NotNull static
+    List<String> getClassNamesForFile(final PsiFile psiFile) {
+        final List<String> classNames = new ArrayList<String>();
+        if (!(psiFile instanceof PsiJavaFile)) {
+            return classNames;
+        }
+
+        final PsiJavaFile psiJavaFile = (PsiJavaFile)psiFile;
+        final PsiClass[] classes = psiJavaFile.getClasses();
+        for (final PsiClass pc : classes) {
+            classNames.add(pc.getQualifiedName());
+        }
+        return classNames;
+    }
+
+    @NotNull static
+    List<String> getClassNamesInDirectory(final PsiDirectory psiDirectory) {
+        final List<String> classNames = new ArrayList<String>();
+        if (psiDirectory == null) {
+            return classNames;
+        }
+
+        final PsiDirectory[] directories = psiDirectory.getSubdirectories();
+        for (final PsiDirectory d: directories) {
+            classNames.addAll(getClassNamesInDirectory(d));
+        }
+
+        final PsiFile[] files = psiDirectory.getFiles();
+        for (final PsiFile f : files) {
+            classNames.addAll(getClassNamesForFile(f));
+        }
+        return classNames;
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitTestSomeClassesAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/PitTestSomeClassesAction.java
@@ -1,0 +1,58 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.openapi.fileTypes.StdFileTypes;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+import pl.mjedynak.idea.plugins.pit.cli.PitCommandLineArgumentsContainer;
+import pl.mjedynak.idea.plugins.pit.cli.factory.DefaultArgumentsContainerFactory;
+import pl.mjedynak.idea.plugins.pit.cli.factory.DefaultArgumentsContainerPopulator;
+import pl.mjedynak.idea.plugins.pit.configuration.PitConfigurationType;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfiguration;
+
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_CLASSES;
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_TESTS;
+
+/**
+ * Runs pitest filtered to a directory of code
+ */
+public class PitTestSomeClassesAction extends DirectoryOrFilePitAction {
+
+    @Override
+    String getTitleForItem(final String item) {
+        return "Pitest classes in '" + item + "'";
+    }
+
+    @Override
+    boolean isEnabled(@NotNull final Project project, @NotNull final Module module, @NotNull final VirtualFile vfile) {
+        return (vfile.isDirectory() || (vfile.getFileType() == StdFileTypes.JAVA))
+                && module.getModuleContentScope().contains(vfile)
+                && !module.getModuleTestsWithDependentsScope().contains(vfile);
+    }
+
+    @Override
+    PitRunConfiguration makeConfigurationForClassList(@NotNull final String classList, @NotNull final Project project, @NotNull final String title) {
+        final DefaultArgumentsContainerPopulator defaultArgumentsContainerPopulator = new DefaultArgumentsContainerPopulator(
+                ProjectRootManager.getInstance(project), PsiManager.getInstance(project));
+
+        final DefaultArgumentsContainerFactory defaultArgumentsContainerFactory
+                = new DefaultArgumentsContainerFactory(defaultArgumentsContainerPopulator) {
+            @Override
+            public PitCommandLineArgumentsContainer createDefaultPitCommandLineArgumentsContainer(final Project proj) {
+                final PitCommandLineArgumentsContainer container = super.createDefaultPitCommandLineArgumentsContainer(proj);
+                container.put(TARGET_CLASSES, classList);
+                container.put(TARGET_TESTS, "*");
+                return container;
+            }
+        };
+
+        return new PitRunConfiguration("PIT for classes in " + title, project,
+                PitConfigurationType.getInstance().getConfigurationFactories()[0],
+                defaultArgumentsContainerFactory);
+
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/RunAllPitAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/RunAllPitAction.java
@@ -1,0 +1,20 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.project.Project;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfiguration;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfigurationFactory;
+
+
+public class RunAllPitAction extends PitAction {
+
+    protected PitRunConfiguration getConfigurationForActionEvent(final AnActionEvent e) {
+        final Project project = e.getData(DataKeys.PROJECT);
+
+        final PitRunConfigurationFactory pitRunConfigurationFactory = new PitRunConfigurationFactory();
+        return pitRunConfigurationFactory.createConfiguration(project);
+
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/actions/RunSomeTestsPitAction.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/actions/RunSomeTestsPitAction.java
@@ -1,0 +1,56 @@
+package pl.mjedynak.idea.plugins.pit.actions;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.StdFileTypes;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+import pl.mjedynak.idea.plugins.pit.cli.PitCommandLineArgumentsContainer;
+import pl.mjedynak.idea.plugins.pit.cli.factory.DefaultArgumentsContainerFactory;
+import pl.mjedynak.idea.plugins.pit.cli.factory.DefaultArgumentsContainerPopulator;
+import pl.mjedynak.idea.plugins.pit.configuration.PitConfigurationType;
+import pl.mjedynak.idea.plugins.pit.configuration.PitRunConfiguration;
+
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_TESTS;
+
+/**
+ * Runs pitest filtered to a directory of test files
+ */
+public class RunSomeTestsPitAction extends DirectoryOrFilePitAction {
+
+    boolean isEnabled(@NotNull final Project project, @NotNull final Module module,
+                               @NotNull final VirtualFile vfile) {
+        return (vfile.isDirectory() || (vfile.getFileType() == StdFileTypes.JAVA)) &&
+                module.getModuleTestsWithDependentsScope().contains(vfile);
+    }
+
+    @Override
+    String getTitleForItem(final String item) {
+        return "Pitest using tests in '" + item + "'";
+    }
+
+    @Override
+    PitRunConfiguration makeConfigurationForClassList(@NotNull final String classList, @NotNull final Project project, @NotNull final String title) {
+        final DefaultArgumentsContainerPopulator defaultArgumentsContainerPopulator = new DefaultArgumentsContainerPopulator(
+                ProjectRootManager.getInstance(project), PsiManager.getInstance(project));
+
+        final DefaultArgumentsContainerFactory defaultArgumentsContainerFactory
+                = new DefaultArgumentsContainerFactory(defaultArgumentsContainerPopulator) {
+            @Override
+            public PitCommandLineArgumentsContainer createDefaultPitCommandLineArgumentsContainer(final Project proj) {
+                final PitCommandLineArgumentsContainer container = super.createDefaultPitCommandLineArgumentsContainer(proj);
+                container.put(TARGET_TESTS, classList);
+                return container;
+            }
+        };
+
+        return new PitRunConfiguration("PIT using tests in " + title, project,
+                PitConfigurationType.getInstance().getConfigurationFactories()[0],
+                defaultArgumentsContainerFactory);
+
+    }
+
+}

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/cli/model/PitCommandLineArgument.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/cli/model/PitCommandLineArgument.java
@@ -4,6 +4,7 @@ public enum PitCommandLineArgument {
     REPORT_DIR("--reportDir"),
     SOURCE_DIRS("--sourceDirs"),
     TARGET_CLASSES("--targetClasses"),
+    TARGET_TESTS("--targetTests"),
     INCLUDE_LAUNCH_CLASSPATH("--includeLaunchClasspath"),
     CLASSPATH("--classPath");
 

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/gui/PitConfigurationForm.form
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/gui/PitConfigurationForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="pl.mjedynak.idea.plugins.pit.gui.PitConfigurationForm">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -18,7 +18,7 @@
       </component>
       <vspacer id="abb3">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="71aa0" class="javax.swing.JLabel" binding="targetClassesLabel">
@@ -29,7 +29,15 @@
           <text value="Target classes"/>
         </properties>
       </component>
-      <component id="403a5" class="javax.swing.JTextField" binding="sourceDirTextField">
+      <component id="67482" class="javax.swing.JLabel" binding="targetTestsLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Target tests"/>
+        </properties>
+      </component>
+      <component id="60ce5" class="javax.swing.JTextField" binding="targetTestsTextField">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
@@ -37,15 +45,7 @@
         </constraints>
         <properties/>
       </component>
-      <component id="586ff" class="javax.swing.JLabel" binding="sourceDirLabel">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="Source dir"/>
-        </properties>
-      </component>
-      <component id="2e93a" class="javax.swing.JTextField" binding="reportDirTextField">
+      <component id="403a5" class="javax.swing.JTextField" binding="sourceDirTextField">
         <constraints>
           <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
@@ -53,15 +53,15 @@
         </constraints>
         <properties/>
       </component>
-      <component id="d3ce8" class="javax.swing.JLabel" binding="reportDirLabel">
+      <component id="586ff" class="javax.swing.JLabel" binding="sourceDirLabel">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Report dir"/>
+          <text value="Source dir"/>
         </properties>
       </component>
-      <component id="c59d0" class="javax.swing.JTextField" binding="otherParamsTextField">
+      <component id="2e93a" class="javax.swing.JTextField" binding="reportDirTextField">
         <constraints>
           <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
@@ -69,9 +69,25 @@
         </constraints>
         <properties/>
       </component>
-      <component id="7fec2" class="javax.swing.JLabel" binding="otherParamsLabel">
+      <component id="d3ce8" class="javax.swing.JLabel" binding="reportDirLabel">
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Report dir"/>
+        </properties>
+      </component>
+      <component id="c59d0" class="javax.swing.JTextField" binding="otherParamsTextField">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="7fec2" class="javax.swing.JLabel" binding="otherParamsLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Other params"/>

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/gui/PitConfigurationForm.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/gui/PitConfigurationForm.java
@@ -26,6 +26,8 @@ public class PitConfigurationForm extends SettingsEditor<PitRunConfiguration> {
     private JTextField reportDirTextField;
     private JTextField otherParamsTextField;
     private JLabel otherParamsLabel;
+    private JTextField targetTestsTextField;
+    private JLabel targetTestsLabel;
 
 
     public String getReportDir() {
@@ -38,6 +40,10 @@ public class PitConfigurationForm extends SettingsEditor<PitRunConfiguration> {
 
     public String getTargetClasses() {
         return targetClassesTextField.getText();
+    }
+
+    public String getTargetTests() {
+        return targetTestsTextField.getText();
     }
 
     public String getOtherParams() {
@@ -54,6 +60,10 @@ public class PitConfigurationForm extends SettingsEditor<PitRunConfiguration> {
 
     public void setTargetClasses(String targetClasses) {
         targetClassesTextField.setText(targetClasses);
+    }
+
+    public void setTargetTests(String targetTests) {
+        targetTestsTextField.setText(targetTests);
     }
 
     public void setOtherParams(String otherParams) {

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/gui/populator/PitConfigurationFormPopulator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/gui/populator/PitConfigurationFormPopulator.java
@@ -6,6 +6,7 @@ import pl.mjedynak.idea.plugins.pit.gui.PitConfigurationForm;
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.REPORT_DIR;
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.SOURCE_DIRS;
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_CLASSES;
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_TESTS;
 
 public class PitConfigurationFormPopulator {
 
@@ -15,12 +16,18 @@ public class PitConfigurationFormPopulator {
         setReportDir(pitConfigurationForm, pitCommandLineArgumentsContainer);
         setSourceDir(pitConfigurationForm, pitCommandLineArgumentsContainer);
         setTargetClasses(pitConfigurationForm, pitCommandLineArgumentsContainer);
+        setTargetTests(pitConfigurationForm, pitCommandLineArgumentsContainer);
         setOtherParams(pitConfigurationForm);
     }
 
     private void setTargetClasses(PitConfigurationForm pitConfigurationForm, PitCommandLineArgumentsContainer pitCommandLineArgumentsContainer) {
         String targetClasses = pitCommandLineArgumentsContainer.get(TARGET_CLASSES);
         pitConfigurationForm.setTargetClasses(targetClasses);
+    }
+
+    private void setTargetTests(PitConfigurationForm pitConfigurationForm, PitCommandLineArgumentsContainer pitCommandLineArgumentsContainer) {
+        String targetTests = pitCommandLineArgumentsContainer.get(TARGET_TESTS);
+        pitConfigurationForm.setTargetTests(targetTests);
     }
 
     private void setSourceDir(PitConfigurationForm pitConfigurationForm, PitCommandLineArgumentsContainer pitCommandLineArgumentsContainer) {

--- a/src/main/java/pl/mjedynak/idea/plugins/pit/gui/populator/ProgramParametersListPopulator.java
+++ b/src/main/java/pl/mjedynak/idea/plugins/pit/gui/populator/ProgramParametersListPopulator.java
@@ -8,6 +8,7 @@ import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.INCL
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.REPORT_DIR;
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.SOURCE_DIRS;
 import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_CLASSES;
+import static pl.mjedynak.idea.plugins.pit.cli.model.PitCommandLineArgument.TARGET_TESTS;
 
 public class ProgramParametersListPopulator {
 
@@ -15,6 +16,7 @@ public class ProgramParametersListPopulator {
         addReportDir(programParametersList, pitConfigurationForm);
         addSourceDir(programParametersList, pitConfigurationForm);
         addTargetClasses(programParametersList, pitConfigurationForm);
+        addTargetTests(programParametersList, pitConfigurationForm);
         addOtherParams(programParametersList, pitConfigurationForm);
         programParametersList.add(INCLUDE_LAUNCH_CLASSPATH.getName(), "false");
         programParametersList.add(CLASSPATH.getName(), pitClassPath);
@@ -33,6 +35,14 @@ public class ProgramParametersListPopulator {
     private void addTargetClasses(ParametersList programParametersList, PitConfigurationForm pitConfigurationForm) {
         programParametersList.add(TARGET_CLASSES.getName());
         programParametersList.add(pitConfigurationForm.getTargetClasses());
+    }
+
+    private void addTargetTests(ParametersList programParametersList, PitConfigurationForm pitConfigurationForm) {
+        /* Only add this parameter if it is set - otherwise default is the target classes */
+        if (!pitConfigurationForm.getTargetTests().isEmpty()) {
+            programParametersList.add(TARGET_TESTS.getName());
+            programParametersList.add(pitConfigurationForm.getTargetTests());
+        }
     }
 
     private void addOtherParams(ParametersList programParametersList, PitConfigurationForm pitConfigurationForm) {

--- a/src/test/groovy/pl/mjedynak/idea/plugins/pit/gui/populator/PitConfigurationFormPopulatorTest.groovy
+++ b/src/test/groovy/pl/mjedynak/idea/plugins/pit/gui/populator/PitConfigurationFormPopulatorTest.groovy
@@ -14,11 +14,13 @@ class PitConfigurationFormPopulatorTest extends Specification {
     String reportDir = 'reportDir'
     String sourceDir = 'srcDir'
     String targetClasses = 'targetClasses'
+    String targetTests = 'targetTests'
 
     def "should populate form text fields using argument container created by factory"() {
         pitCommandLineArgumentsContainer.get(PitCommandLineArgument.REPORT_DIR) >> reportDir
         pitCommandLineArgumentsContainer.get(PitCommandLineArgument.SOURCE_DIRS) >> sourceDir
         pitCommandLineArgumentsContainer.get(PitCommandLineArgument.TARGET_CLASSES) >> targetClasses
+        pitCommandLineArgumentsContainer.get(PitCommandLineArgument.TARGET_TESTS) >> targetTests
 
         when:
         pitConfigurationFormPopulator.populateTextFieldsInForm(pitConfigurationForm, pitCommandLineArgumentsContainer)
@@ -27,6 +29,7 @@ class PitConfigurationFormPopulatorTest extends Specification {
         1 * pitConfigurationForm.setReportDir(reportDir)
         1 * pitConfigurationForm.setSourceDir(sourceDir)
         1 * pitConfigurationForm.setTargetClasses(targetClasses)
+        1 * pitConfigurationForm.setTargetTests(targetTests)
         1 * pitConfigurationForm.setOtherParams(pitConfigurationFormPopulator.OTHER_PARAMS)
     }
 }


### PR DESCRIPTION
I added some context menu actions to:

- Run pitest on the whole suite and all classes (default params)
- Run pitest on a directort of test classes (measuring coverage over all code)
- Run pitest on a directory of code classes (using all tests)

To make this work nicely I had to add support for the `--targetTests` commandline parameter. For convenience I based this patch on @divyakumarjain's patch for #18, but I could rebase it if needed.

Marking as WIP for now because it includes that other patch (and my patch for #26) and not sure it should be merged as-is.  Happy to get feedback though.