### PR TITLE
Add JUnit 5 Plugin to Classpath

### DIFF
--- a/src/main/groovy/pl/mjedynak/idea/plugins/pit/ClassPathPopulator.groovy
+++ b/src/main/groovy/pl/mjedynak/idea/plugins/pit/ClassPathPopulator.groovy
@@ -24,6 +24,7 @@ class ClassPathPopulator {
             addFirst(path + 'xstream-1.4.8.jar')
             addFirst(path + 'xmlpull-1.1.3.1.jar')
             addFirst(path + 'xpp3_min-1.1.4c.jar')
+            addFirst(path + 'pitest-junit5-plugin-0.12.jar')
         }
     }
 }


### PR DESCRIPTION
At the moment, users who use the junit5 testing framework cannot run pitest from intellij without adding a dependency on pitest-junit5-plugin (#46). This is somewhat cumbersome and as the pitest-junit5-plugin jar also have packaged with it the code for several other dependencies, it can sometimes cause conflicts on the classpath in the user's project.

With the proposed change, junit 5 users only need to specify --testPlugin=junit5 in otherParams and pitest will work correctly. For usersof other junit versions, the additional jar on the classpath will just be redundant and should not cause them any problems.